### PR TITLE
Make the officer return to the stackup position without looking away …

### DIFF
--- a/Source/Game/SwatAICommon/Classes/Squads/Actions/SquadMirrorDoorAction.uc
+++ b/Source/Game/SwatAICommon/Classes/Squads/Actions/SquadMirrorDoorAction.uc
@@ -114,10 +114,7 @@ state Running
 
 	MirrorDoor();
 
-	if(!bOfficersWerentStacked)
-	{
-		StackUpOfficer(OfficerWithMirror, StackUpPoints[0]);
-	}
+	StackUpSquad(true);
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
…from the door

Reordering stackup is the solution I found to the problem the cause officers to look away from the door after mirroring under the door.
Note that this will only work for the officer that actually deploys the optwand. That means if other officers are in the wrong angle, they will remain that way